### PR TITLE
Add support for empty view mode

### DIFF
--- a/custom_components/ticktick/ticktick_api_python/models/project.py
+++ b/custom_components/ticktick/ticktick_api_python/models/project.py
@@ -63,7 +63,7 @@ class Project:
             sortOrder=data["sortOrder"],
             closed=data.get("closed"),
             viewMode=ViewMode(data["viewMode"])
-            if data.get("viewMode") is not None
+            if data.get("viewMode") is not None and data.get("viewMode") != ""
             else None,
             permission=Permission(data["permission"])
             if data.get("permission") is not None


### PR DESCRIPTION
I couldn't get it to work, as it kept trying to map an empty view mode.
So i added to your clause and made it `None` on empty as well.

Might be that my account already exists for a while, that it's saved in their database as empty?