### PR TITLE
fix: startdate and enddate description

### DIFF
--- a/custom_components/ticktick/services.yaml
+++ b/custom_components/ticktick/services.yaml
@@ -52,14 +52,14 @@ create_task:
         boolean: null
     startDate:
       name: Start Date
-      description: "Start date and time in 'yyyy-MM-dd'T'HH:mm:ssZ' format."
-      example: 2024-12-29T03:00:00+0000
+      description: "Start date and time in 'yyyy-MM-dd HH:mm:ss' format."
+      example: 2024-12-29 03:00:00
       selector:
         datetime: {}
     dueDate:
       name: Due Date
-      description: "Due date and time in 'yyyy-MM-dd'T'HH:mm:ssZ' format."
-      example: 2025-01-10T03:00:00+0000
+      description: "Due date and time in 'yyyy-MM-dd HH:mm:ss' format."
+      example: 2025-01-10T03:00:00
       selector:
         datetime: {}
 


### PR DESCRIPTION
Thank you for your hard work on this component! ❤️ 

In my testing, it seems that the expected Date/Time format is `2025-02-04 20:00:00` - without a "T" separator and without a timezone (it appears that the timeZone field handles the timezone part correctly). It is possible that I'm just doing something wrong, in which case I would appreciate your expertise 😄 

## Steps to reproduce

Switch to YAML mode for the action:

```
action: ticktick.create_task
metadata: {}
data:
  projectId: <PROJECT_ID>
  title: Test Task with Due Date
  startDate: "{{ (now() + timedelta(hours=8)).replace(tzinfo=None).isoformat(sep=' ', timespec='seconds') }}"
  timeZone: America/Denver
response_variable: taskId
```

Note that `startDate: "{{ (now() + timedelta(hours=8)).replace(tzinfo=None).isoformat(timespec='seconds') }}"` (without the sep parameter) does not appear to work. The action says it runs successfully, but the task does not get created on my list.

### Alternative approach

1. Start off in the Visual Editor for the action
2. Check the "Start Date" checkbox
3. Enter a date and time
4. Switch to YAML mode
5. Note that the format matches `%Y-%m-%d %H:%M:%S` ([format code reference](https://docs.python.org/3/library/datetime.html#format-codes))