### PR TITLE
Serialise CheckListItem Children of a Task

### DIFF
--- a/custom_components/ticktick/ticktick_api_python/models/check_list_item.py
+++ b/custom_components/ticktick/ticktick_api_python/models/check_list_item.py
@@ -53,3 +53,38 @@ class CheckListItem:
             timeZone=data.get("timeZone"),
             status=TaskStatus(data.get("status", TaskStatus.NORMAL.value)),
         )
+
+    def to_dict(self) -> dict:
+        """Convert this checklist item to a JSON-ready dict."""
+        def _tt_datetime(val):
+            """Convert datetime/int/str to TickTick-compatible string."""
+            if val is None:
+                return None
+            if isinstance(val, datetime):
+                s = val.isoformat()
+            elif isinstance(val, int):
+                # TickTick usually uses ms timestamps
+                s = datetime.fromtimestamp(val / 1000).isoformat()
+            elif isinstance(val, str):
+                # Assume it’s already an ISO string
+                s = val
+            else:
+                return None
+
+            # strip colon in timezone offset, e.g. 2025-08-29T12:00:00+10:00 → +1000
+            if len(s) >= 6 and s[-3] == ":":
+                s = s[:-3] + s[-2:]
+            return s
+
+        d = {
+            "id": self.id,
+            "title": self.title,
+            "isAllDay": self.isAllDay,
+            "sortOrder": self.sortOrder,
+            "startDate": _tt_datetime(self.startDate),
+            "completedTime": _tt_datetime(self.completedTime),
+            "timeZone": self.timeZone,
+            "status": int(self.status) if self.status is not None else None,
+        }
+        # Drop None values so TickTick accepts it
+        return {k: v for k, v in d.items() if v is not None}

--- a/custom_components/ticktick/ticktick_api_python/models/task.py
+++ b/custom_components/ticktick/ticktick_api_python/models/task.py
@@ -68,7 +68,7 @@ class Task(CheckListItem):
 
     def toJSON(self):
         """Serialize Task to json."""
-        
+
         def filter_none(d):
             """Filter out None values from dictionary."""
             return {
@@ -77,8 +77,9 @@ class Task(CheckListItem):
                 if v is not None and v != []
             }
 
+        @staticmethod
         def _handle_datetime(value):
-            # Datetime → ISO without colon in TZ; Enum → .value; pass others through
+            """Handle special cases for JSON serialization."""
             if isinstance(value, datetime):
                 # Removing `:` from the timezone information as TickTick doesnt accept them
                 modified_date = value.isoformat().rsplit(":", 1)

--- a/custom_components/ticktick/ticktick_api_python/models/task.py
+++ b/custom_components/ticktick/ticktick_api_python/models/task.py
@@ -68,21 +68,24 @@ class Task(CheckListItem):
 
     def toJSON(self):
         """Serialize Task to json."""
+        
+        def filter_none(d):
+            """Filter out None values from dictionary."""
+            return {
+                k: _handle_datetime(v)
+                for k, v in d.items()
+                if v is not None and v != []
+            }
 
         def _handle_datetime(value):
             # Datetime → ISO without colon in TZ; Enum → .value; pass others through
             if isinstance(value, datetime):
-                s = value.isoformat()
-                # strip last colon in timezone offset, e.g. +10:00 -> +1000
-                if len(s) >= 6 and s[-3] == ":":
-                    s = s[:-3] + s[-2:]
-                return s
+                # Removing `:` from the timezone information as TickTick doesnt accept them
+                modified_date = value.isoformat().rsplit(":", 1)
+                return modified_date[0] + modified_date[1]
             if isinstance(value, Enum):
                 return value.value
             return value
-
-        def filter_none(d: dict):
-            return {k: _handle_datetime(v) for k, v in d.items() if v is not None and v != []}
 
         d = filter_none(self.__dict__)
 


### PR DESCRIPTION
Previously, updating a task which had CheckListItem children would fail, because attempting to JSON serialise CheckListItem objects would fail. This pull request adds a to_dict function to check_list_item.py, and modifies task.py to iterate through the list and serialise it. Behaviour is identical if there are no child items.

This would resolve #30.