### PR TITLE
Support Dida365 China service endpoint and auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,9 +15,8 @@ Integration implements [TickTick Open API](https://developer.ticktick.com/docs#/
 1. Based on where your account is registered, go to [TickTick Developer](https://developer.ticktick.com/manage) for **TickTick (international)** or [Dida365 Developer](https://developer.dida365.com/manage) for **Dida365 (China)**, then click `New App`.
 2. Name your app and set `OAuth redirect URL` to `https://my.home-assistant.io/redirect/oauth` or your instance url i.e `http://homeassistant.local:8123`
 3. Add this repository in HACS and download TickTick Integration via HACS
-4. In Settings → Devices & services, use the dotted menu to create new application credentials (`/config/application_credentials`).
-5. Enter the OAuth client ID and secret from the app you created.
-6. Your TickTick Lists should now each turn up as a todo list in Home Assistant.
+4. In Settings → Devices & services, use the dotted menu to create new application credentials (`/config/application_credentials`) and enter the OAuth client ID and secret from the app you created.
+5. Your TickTick Lists should now each turn up as a todo list in Home Assistant.
 
 If you don’t want all of your lists to show up in the todo list app, you can disable selected lists in the entities list
 (enter selection mode → Disable selected).

--- a/README.md
+++ b/README.md
@@ -18,6 +18,9 @@ Integration implements [TickTick Open API](https://developer.ticktick.com/docs#/
 4. In Settings → Devices & services, use the dotted menu to create new application credentials (`/config/application_credentials`). Enter the OAuth client ID and secret from the TickTick app here.
 5. Your TickTick Lists should now each turn up as a todo list in Home Assistant.
 
+To use another TickTick-compatible service, open the integration options and set the
+API endpoint, for example `https://api.dida365.com`.
+
 If you don’t want all of your lists to show up in the todo list app, you can disable selected lists in the entities list
 (enter selection mode → Disable selected).
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Integration implements [TickTick Open API](https://developer.ticktick.com/docs#/
 4. In Settings → Devices & services, use the dotted menu to create new application credentials (`/config/application_credentials`). Enter the OAuth client ID and secret from the app for the selected service here. TickTick and Dida365 credentials are not interchangeable.
 5. Your TickTick Lists should now each turn up as a todo list in Home Assistant.
 
-5. During integration setup, select the matching service. The selected service controls
+6. During integration setup, select the matching service. The selected service controls
 the OAuth and API endpoints together.
 
 If you don’t want all of your lists to show up in the todo list app, you can disable selected lists in the entities list

--- a/README.md
+++ b/README.md
@@ -12,12 +12,12 @@ Integration implements [TickTick Open API](https://developer.ticktick.com/docs#/
 
 ## Installation
 
-1. Choose the service you use: [TickTick Developer](https://developer.ticktick.com/manage) for TickTick, or [Dida365 Developer](https://developer.dida365.com/manage) for Dida365, then click `New App`
+1. Choose the service you use: [TickTick Developer](https://developer.ticktick.com/manage) for **TickTick (international)**, or [Dida365 Developer](https://developer.dida365.com/manage) for **Dida365 (China region)**, then click `New App`
 2. Name your app and set `OAuth redirect URL` to `https://my.home-assistant.io/redirect/oauth` or your instance url i.e `http://homeassistant.local:8123`
 3. Add this repository in HACS and download TickTick Integration via HACS
 4. In Settings → Devices & services, use the dotted menu to create new application credentials (`/config/application_credentials`).
 5. Choose the matching credential manually in Home Assistant's application credentials UI and enter its OAuth client ID and secret. Note that the UI may not automatically distinguish between TickTick and Dida365 credentials, which are not interchangeable.
-6. During integration setup, select the matching service. The selected service determines which OAuth and API endpoints will be used.
+6. During integration setup, select the matching service: **TickTick (international)** or **Dida365 (China region)**. The selected service determines the OAuth authorization/token endpoints and API base URL used by the integration.
 7. Your TickTick Lists should now each turn up as a todo list in Home Assistant.
 
 If you don’t want all of your lists to show up in the todo list app, you can disable selected lists in the entities list

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Integration implements [TickTick Open API](https://developer.ticktick.com/docs#/
 3. Add this repository in HACS and download TickTick Integration via HACS
 4. In Settings → Devices & services, use the dotted menu to create new application credentials (`/config/application_credentials`).
 5. In Home Assistant's application credentials UI, select the matching service and enter its OAuth client ID and secret. TickTick and Dida365 credentials are not interchangeable.
-6. During integration setup, select the same service; it determines the OAuth and API endpoints.
+6. During integration setup, select the service chosen in step 1; it determines the OAuth and API endpoints.
 7. Your TickTick Lists should now each turn up as a todo list in Home Assistant.
 
 If you don’t want all of your lists to show up in the todo list app, you can disable selected lists in the entities list

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 ![GitHub Repo stars](https://img.shields.io/github/stars/Hantick/ticktick-home-assistant?style=for-the-badge&color=%23AFB0CC)
 ![GitHub Release](https://img.shields.io/github/v/release/Hantick/ticktick-home-assistant?style=for-the-badge&color=%231CB00A)
 
-Integration implements [TickTick Open API](https://developer.ticktick.com/docs#/openapi) with support for [To-do list](https://www.home-assistant.io/integrations/todo/) entities and exposes it as services in Home Assistant, allowing you to manage your tasks and projects programmatically 😎
+Integration implements [TickTick Open API](https://developer.ticktick.com/docs#/openapi) and [Dida365 Open API](https://developer.dida365.com/docs#/openapi) with support for [To-do list](https://www.home-assistant.io/integrations/todo/) entities and exposes them as services in Home Assistant, allowing you to manage your tasks and projects programmatically 😎
 
 ## Buy me a coffee or beer 🍻
 <a href="https://paypal.me/hantick" target="_blank" rel="noopener noreferrer">
@@ -16,7 +16,8 @@ Integration implements [TickTick Open API](https://developer.ticktick.com/docs#/
 2. Name your app and set `OAuth redirect URL` to `https://my.home-assistant.io/redirect/oauth` or your instance url i.e `http://homeassistant.local:8123`
 3. Add this repository in HACS and download TickTick Integration via HACS
 4. In Settings → Devices & services, use the dotted menu to create new application credentials (`/config/application_credentials`) and enter the OAuth client ID and secret from the app you created.
-5. Your TickTick Lists should now each turn up as a todo list in Home Assistant.
+5. Add the TickTick integration and select the same service you used for the developer app: **TickTick (international)** or **Dida365 (China region)**.
+6. Your TickTick/Dida365 lists should now each turn up as a todo list in Home Assistant.
 
 If you don’t want all of your lists to show up in the todo list app, you can disable selected lists in the entities list
 (enter selection mode → Disable selected).

--- a/README.md
+++ b/README.md
@@ -12,14 +12,14 @@ Integration implements [TickTick Open API](https://developer.ticktick.com/docs#/
 
 ## Installation
 
-1. Navigate to [TickTick Developer](https://developer.ticktick.com/manage) and click `New App`
+1. Choose the service you use: [TickTick Developer](https://developer.ticktick.com/manage) for TickTick, or [Dida365 Developer](https://developer.dida365.com/manage) for Dida365, then click `New App`
 2. Name your app and set `OAuth redirect URL` to `https://my.home-assistant.io/redirect/oauth` or your instance url i.e `http://homeassistant.local:8123`
 3. Add this repository in HACS and download TickTick Integration via HACS
-4. In Settings → Devices & services, use the dotted menu to create new application credentials (`/config/application_credentials`). Enter the OAuth client ID and secret from the TickTick app here.
+4. In Settings → Devices & services, use the dotted menu to create new application credentials (`/config/application_credentials`). Enter the OAuth client ID and secret from the app for the selected service here. TickTick and Dida365 credentials are not interchangeable.
 5. Your TickTick Lists should now each turn up as a todo list in Home Assistant.
 
-To use another TickTick-compatible service, open the integration options and set the
-API endpoint, for example `https://api.dida365.com`.
+5. During integration setup, select the matching service. The selected service controls
+the OAuth and API endpoints together.
 
 If you don’t want all of your lists to show up in the todo list app, you can disable selected lists in the entities list
 (enter selection mode → Disable selected).

--- a/README.md
+++ b/README.md
@@ -17,10 +17,9 @@ Integration implements [TickTick Open API](https://developer.ticktick.com/docs#/
 3. Add this repository in HACS and download TickTick Integration via HACS
 4. In Settings → Devices & services, use the dotted menu to create new application credentials (`/config/application_credentials`).
 5. Enter the OAuth client ID and secret from the app for the selected service. TickTick and Dida365 credentials are not interchangeable.
-6. Your TickTick Lists should now each turn up as a todo list in Home Assistant.
-
-7. During integration setup, select the matching service. The selected service controls
+6. During integration setup, select the matching service. The selected service controls
 the OAuth and API endpoints together.
+7. Your TickTick Lists should now each turn up as a todo list in Home Assistant.
 
 If you don’t want all of your lists to show up in the todo list app, you can disable selected lists in the entities list
 (enter selection mode → Disable selected).

--- a/README.md
+++ b/README.md
@@ -12,13 +12,12 @@ Integration implements [TickTick Open API](https://developer.ticktick.com/docs#/
 
 ## Installation
 
-1. Choose the service you use: [TickTick Developer](https://developer.ticktick.com/manage) for **TickTick (international)**, or [Dida365 Developer](https://developer.dida365.com/manage) for **Dida365 (China region)**, then click `New App`
+1. Choose [TickTick Developer](https://developer.ticktick.com/manage) for **TickTick (international)** or [Dida365 Developer](https://developer.dida365.com/manage) for **Dida365 (China)**, then click `New App`.
 2. Name your app and set `OAuth redirect URL` to `https://my.home-assistant.io/redirect/oauth` or your instance url i.e `http://homeassistant.local:8123`
 3. Add this repository in HACS and download TickTick Integration via HACS
 4. In Settings → Devices & services, use the dotted menu to create new application credentials (`/config/application_credentials`).
-5. Choose the matching credential manually in Home Assistant's application credentials UI and enter its OAuth client ID and secret. That UI may not distinguish TickTick and Dida365 credentials automatically; their credentials are not interchangeable.
-6. During integration setup, select the matching service. The selected service controls
-the OAuth and API endpoints together.
+5. In Home Assistant's application credentials UI, select the matching service and enter its OAuth client ID and secret. TickTick and Dida365 credentials are not interchangeable.
+6. During integration setup, select the same service for the corresponding OAuth and API endpoints.
 7. Your TickTick Lists should now each turn up as a todo list in Home Assistant.
 
 If you don’t want all of your lists to show up in the todo list app, you can disable selected lists in the entities list

--- a/README.md
+++ b/README.md
@@ -16,9 +16,8 @@ Integration implements [TickTick Open API](https://developer.ticktick.com/docs#/
 2. Name your app and set `OAuth redirect URL` to `https://my.home-assistant.io/redirect/oauth` or your instance url i.e `http://homeassistant.local:8123`
 3. Add this repository in HACS and download TickTick Integration via HACS
 4. In Settings → Devices & services, use the dotted menu to create new application credentials (`/config/application_credentials`).
-5. Choose the matching credential manually in Home Assistant's application credentials UI and enter its OAuth client ID and secret. That UI may not distinguish TickTick and Dida365 credentials automatically; their credentials are not interchangeable.
-6. During integration setup, select the matching service. The selected service controls
-the OAuth and API endpoints together.
+5. Choose the matching credential manually in Home Assistant's application credentials UI and enter its OAuth client ID and secret. Note that the UI may not automatically distinguish between TickTick and Dida365 credentials, which are not interchangeable.
+6. During integration setup, select the matching service. The selected service determines which OAuth and API endpoints will be used.
 7. Your TickTick Lists should now each turn up as a todo list in Home Assistant.
 
 If you don’t want all of your lists to show up in the todo list app, you can disable selected lists in the entities list

--- a/README.md
+++ b/README.md
@@ -12,12 +12,12 @@ Integration implements [TickTick Open API](https://developer.ticktick.com/docs#/
 
 ## Installation
 
-1. Choose the service you use: [TickTick Developer](https://developer.ticktick.com/manage) for **TickTick (international)**, or [Dida365 Developer](https://developer.dida365.com/manage) for **Dida365 (China region)**, then click `New App`
+1. Choose the service you use: [TickTick Developer](https://developer.ticktick.com/manage) for TickTick, or [Dida365 Developer](https://developer.dida365.com/manage) for Dida365, then click `New App`
 2. Name your app and set `OAuth redirect URL` to `https://my.home-assistant.io/redirect/oauth` or your instance url i.e `http://homeassistant.local:8123`
 3. Add this repository in HACS and download TickTick Integration via HACS
 4. In Settings → Devices & services, use the dotted menu to create new application credentials (`/config/application_credentials`).
 5. Choose the matching credential manually in Home Assistant's application credentials UI and enter its OAuth client ID and secret. Note that the UI may not automatically distinguish between TickTick and Dida365 credentials, which are not interchangeable.
-6. During integration setup, select the matching service: **TickTick (international)** or **Dida365 (China region)**. The selected service determines the OAuth authorization/token endpoints and API base URL used by the integration.
+6. During integration setup, select the matching service. The selected service determines which OAuth and API endpoints will be used.
 7. Your TickTick Lists should now each turn up as a todo list in Home Assistant.
 
 If you don’t want all of your lists to show up in the todo list app, you can disable selected lists in the entities list

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Integration implements [TickTick Open API](https://developer.ticktick.com/docs#/
 2. Name your app and set `OAuth redirect URL` to `https://my.home-assistant.io/redirect/oauth` or your instance url i.e `http://homeassistant.local:8123`
 3. Add this repository in HACS and download TickTick Integration via HACS
 4. In Settings → Devices & services, use the dotted menu to create new application credentials (`/config/application_credentials`).
-5. Enter the OAuth client ID and secret from the app for the selected service. TickTick and Dida365 credentials are not interchangeable.
+5. Choose the matching credential manually in the application credentials UI and enter its OAuth client ID and secret. The UI may not distinguish TickTick and Dida365 automatically; their credentials are not interchangeable.
 6. During integration setup, select the matching service. The selected service controls
 the OAuth and API endpoints together.
 7. Your TickTick Lists should now each turn up as a todo list in Home Assistant.

--- a/README.md
+++ b/README.md
@@ -12,12 +12,12 @@ Integration implements [TickTick Open API](https://developer.ticktick.com/docs#/
 
 ## Installation
 
-1. Choose [TickTick Developer](https://developer.ticktick.com/manage) for **TickTick (international)** or [Dida365 Developer](https://developer.dida365.com/manage) for **Dida365 (China)**, then click `New App`.
+1. Choose your service: [TickTick Developer](https://developer.ticktick.com/manage) for **TickTick (international)** or [Dida365 Developer](https://developer.dida365.com/manage) for **Dida365 (China)**, then click `New App`.
 2. Name your app and set `OAuth redirect URL` to `https://my.home-assistant.io/redirect/oauth` or your instance url i.e `http://homeassistant.local:8123`
 3. Add this repository in HACS and download TickTick Integration via HACS
 4. In Settings → Devices & services, use the dotted menu to create new application credentials (`/config/application_credentials`).
 5. In Home Assistant's application credentials UI, select the matching service and enter its OAuth client ID and secret. TickTick and Dida365 credentials are not interchangeable.
-6. During integration setup, select the same service for the corresponding OAuth and API endpoints.
+6. During integration setup, select the same service; it determines the OAuth and API endpoints.
 7. Your TickTick Lists should now each turn up as a todo list in Home Assistant.
 
 If you don’t want all of your lists to show up in the todo list app, you can disable selected lists in the entities list

--- a/README.md
+++ b/README.md
@@ -15,10 +15,11 @@ Integration implements [TickTick Open API](https://developer.ticktick.com/docs#/
 1. Choose the service you use: [TickTick Developer](https://developer.ticktick.com/manage) for TickTick, or [Dida365 Developer](https://developer.dida365.com/manage) for Dida365, then click `New App`
 2. Name your app and set `OAuth redirect URL` to `https://my.home-assistant.io/redirect/oauth` or your instance url i.e `http://homeassistant.local:8123`
 3. Add this repository in HACS and download TickTick Integration via HACS
-4. In Settings → Devices & services, use the dotted menu to create new application credentials (`/config/application_credentials`). Enter the OAuth client ID and secret from the app for the selected service here. TickTick and Dida365 credentials are not interchangeable.
-5. Your TickTick Lists should now each turn up as a todo list in Home Assistant.
+4. In Settings → Devices & services, use the dotted menu to create new application credentials (`/config/application_credentials`).
+5. Enter the OAuth client ID and secret from the app for the selected service. TickTick and Dida365 credentials are not interchangeable.
+6. Your TickTick Lists should now each turn up as a todo list in Home Assistant.
 
-6. During integration setup, select the matching service. The selected service controls
+7. During integration setup, select the matching service. The selected service controls
 the OAuth and API endpoints together.
 
 If you don’t want all of your lists to show up in the todo list app, you can disable selected lists in the entities list

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Integration implements [TickTick Open API](https://developer.ticktick.com/docs#/
 2. Name your app and set `OAuth redirect URL` to `https://my.home-assistant.io/redirect/oauth` or your instance url i.e `http://homeassistant.local:8123`
 3. Add this repository in HACS and download TickTick Integration via HACS
 4. In Settings → Devices & services, use the dotted menu to create new application credentials (`/config/application_credentials`).
-5. Choose the matching credential manually in the application credentials UI and enter its OAuth client ID and secret. The UI may not distinguish TickTick and Dida365 automatically; their credentials are not interchangeable.
+5. Choose the matching credential manually in Home Assistant's application credentials UI and enter its OAuth client ID and secret. That UI may not distinguish TickTick and Dida365 credentials automatically; their credentials are not interchangeable.
 6. During integration setup, select the matching service. The selected service controls
 the OAuth and API endpoints together.
 7. Your TickTick Lists should now each turn up as a todo list in Home Assistant.

--- a/README.md
+++ b/README.md
@@ -12,12 +12,13 @@ Integration implements [TickTick Open API](https://developer.ticktick.com/docs#/
 
 ## Installation
 
-1. Choose the service you use: [TickTick Developer](https://developer.ticktick.com/manage) for TickTick, or [Dida365 Developer](https://developer.dida365.com/manage) for Dida365, then click `New App`
+1. Choose the service you use: [TickTick Developer](https://developer.ticktick.com/manage) for **TickTick (international)**, or [Dida365 Developer](https://developer.dida365.com/manage) for **Dida365 (China region)**, then click `New App`
 2. Name your app and set `OAuth redirect URL` to `https://my.home-assistant.io/redirect/oauth` or your instance url i.e `http://homeassistant.local:8123`
 3. Add this repository in HACS and download TickTick Integration via HACS
 4. In Settings → Devices & services, use the dotted menu to create new application credentials (`/config/application_credentials`).
-5. Choose the matching credential manually in Home Assistant's application credentials UI and enter its OAuth client ID and secret. Note that the UI may not automatically distinguish between TickTick and Dida365 credentials, which are not interchangeable.
-6. During integration setup, select the matching service. The selected service determines which OAuth and API endpoints will be used.
+5. Choose the matching credential manually in Home Assistant's application credentials UI and enter its OAuth client ID and secret. That UI may not distinguish TickTick and Dida365 credentials automatically; their credentials are not interchangeable.
+6. During integration setup, select the matching service. The selected service controls
+the OAuth and API endpoints together.
 7. Your TickTick Lists should now each turn up as a todo list in Home Assistant.
 
 If you don’t want all of your lists to show up in the todo list app, you can disable selected lists in the entities list

--- a/README.md
+++ b/README.md
@@ -12,13 +12,12 @@ Integration implements [TickTick Open API](https://developer.ticktick.com/docs#/
 
 ## Installation
 
-1. Choose your service: [TickTick Developer](https://developer.ticktick.com/manage) for **TickTick (international)** or [Dida365 Developer](https://developer.dida365.com/manage) for **Dida365 (China)**, then click `New App`.
+1. Based on where your account is registered, go to [TickTick Developer](https://developer.ticktick.com/manage) for **TickTick (international)** or [Dida365 Developer](https://developer.dida365.com/manage) for **Dida365 (China)**, then click `New App`.
 2. Name your app and set `OAuth redirect URL` to `https://my.home-assistant.io/redirect/oauth` or your instance url i.e `http://homeassistant.local:8123`
 3. Add this repository in HACS and download TickTick Integration via HACS
 4. In Settings → Devices & services, use the dotted menu to create new application credentials (`/config/application_credentials`).
-5. In Home Assistant's application credentials UI, select the matching service and enter its OAuth client ID and secret. TickTick and Dida365 credentials are not interchangeable.
-6. During integration setup, select the service chosen in step 1; it determines the OAuth and API endpoints.
-7. Your TickTick Lists should now each turn up as a todo list in Home Assistant.
+5. Enter the OAuth client ID and secret from the app you created.
+6. Your TickTick Lists should now each turn up as a todo list in Home Assistant.
 
 If you don’t want all of your lists to show up in the todo list app, you can disable selected lists in the entities list
 (enter selection mode → Disable selected).

--- a/custom_components/ticktick/__init__.py
+++ b/custom_components/ticktick/__init__.py
@@ -61,7 +61,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: TickTickConfigEntry) -> 
         access_token, aiohttp_session, api_base_url
     )
 
-    await register_coordiantor(hass, tickTickApiClient, entry, access_token)
+    await register_coordinator(hass, tickTickApiClient, entry, access_token)
     await register_services(hass, tickTickApiClient)
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
@@ -77,7 +77,7 @@ async def async_unload_entry(hass: HomeAssistant, entry: TickTickConfigEntry) ->
     return unload_ok
 
 
-async def register_coordiantor(
+async def register_coordinator(
     hass: HomeAssistant,
     tickTickApiClient: TickTickAPIClient,
     entry: TickTickConfigEntry,

--- a/custom_components/ticktick/__init__.py
+++ b/custom_components/ticktick/__init__.py
@@ -12,7 +12,8 @@ from homeassistant.core import HomeAssistant, SupportsResponse
 from homeassistant.helpers import aiohttp_client
 
 from . import api
-from .const import CONF_API_ENDPOINT, DEFAULT_API_ENDPOINT, DOMAIN
+from .application_credentials import regionalize_implementation
+from .const import CONF_REGION, DEFAULT_REGION, DOMAIN, REGIONS
 from .coordinator import TickTickCoordinator
 from .service_handlers import (
     handle_complete_task,
@@ -45,6 +46,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: TickTickConfigEntry) -> 
             hass, entry
         )
     )
+    region = entry.data.get(CONF_REGION, DEFAULT_REGION)
+    implementation = regionalize_implementation(hass, implementation, region)
 
     session = config_entry_oauth2_flow.OAuth2Session(hass, entry, implementation)
 
@@ -53,9 +56,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: TickTickConfigEntry) -> 
     entry.runtime_data = api.AsyncConfigEntryAuth(aiohttp_session, session)
     access_token = await entry.runtime_data.async_get_access_token()
 
-    api_endpoint = entry.options.get(CONF_API_ENDPOINT, DEFAULT_API_ENDPOINT)
+    api_base_url = REGIONS.get(region, REGIONS[DEFAULT_REGION])["api_base_url"]
     tickTickApiClient = TickTickAPIClient(
-        access_token, aiohttp_session, api_endpoint
+        access_token, aiohttp_session, api_base_url
     )
 
     await register_coordiantor(hass, tickTickApiClient, entry, access_token)

--- a/custom_components/ticktick/__init__.py
+++ b/custom_components/ticktick/__init__.py
@@ -12,7 +12,7 @@ from homeassistant.core import HomeAssistant, SupportsResponse
 from homeassistant.helpers import aiohttp_client
 
 from . import api
-from .const import DOMAIN
+from .const import CONF_API_ENDPOINT, DEFAULT_API_ENDPOINT, DOMAIN
 from .coordinator import TickTickCoordinator
 from .service_handlers import (
     handle_complete_task,
@@ -53,7 +53,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: TickTickConfigEntry) -> 
     entry.runtime_data = api.AsyncConfigEntryAuth(aiohttp_session, session)
     access_token = await entry.runtime_data.async_get_access_token()
 
-    tickTickApiClient = TickTickAPIClient(access_token, aiohttp_session)
+    api_endpoint = entry.options.get(CONF_API_ENDPOINT, DEFAULT_API_ENDPOINT)
+    tickTickApiClient = TickTickAPIClient(
+        access_token, aiohttp_session, api_endpoint
+    )
 
     await register_coordiantor(hass, tickTickApiClient, entry, access_token)
     await register_services(hass, tickTickApiClient)

--- a/custom_components/ticktick/__init__.py
+++ b/custom_components/ticktick/__init__.py
@@ -61,7 +61,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: TickTickConfigEntry) -> 
         access_token, aiohttp_session, api_base_url
     )
 
-    await register_coordinator(hass, tickTickApiClient, entry, access_token)
+    await register_coordiantor(hass, tickTickApiClient, entry, access_token)
     await register_services(hass, tickTickApiClient)
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
@@ -77,7 +77,7 @@ async def async_unload_entry(hass: HomeAssistant, entry: TickTickConfigEntry) ->
     return unload_ok
 
 
-async def register_coordinator(
+async def register_coordiantor(
     hass: HomeAssistant,
     tickTickApiClient: TickTickAPIClient,
     entry: TickTickConfigEntry,

--- a/custom_components/ticktick/application_credentials.py
+++ b/custom_components/ticktick/application_credentials.py
@@ -33,11 +33,17 @@ class RegionalOAuth2Implementation(
             region_config["token_url"],
         )
         self._name = implementation.name
+        self._region = region
 
     @property
     def name(self) -> str:
         """Return the credential name."""
         return self._name
+
+    @property
+    def region(self) -> str:
+        """Return the selected region."""
+        return self._region
 
 
 async def async_get_authorization_server(hass: HomeAssistant) -> AuthorizationServer:
@@ -55,6 +61,9 @@ def regionalize_implementation(
     region: str,
 ) -> RegionalOAuth2Implementation:
     """Return an OAuth implementation for the selected region."""
-    if isinstance(implementation, RegionalOAuth2Implementation):
+    if (
+        isinstance(implementation, RegionalOAuth2Implementation)
+        and implementation.region == region
+    ):
         return implementation
     return RegionalOAuth2Implementation(hass, implementation, region)

--- a/custom_components/ticktick/application_credentials.py
+++ b/custom_components/ticktick/application_credentials.py
@@ -10,7 +10,11 @@ from .const import DEFAULT_REGION, REGIONS
 class RegionalOAuth2Implementation(
     config_entry_oauth2_flow.LocalOAuth2Implementation
 ):
-    """OAuth implementation using the endpoints for a selected region."""
+    """OAuth implementation using the endpoints for a selected region.
+
+    The application credentials platform provides the client credentials, while
+    this wrapper selects the matching authorize and token endpoints.
+    """
 
     def __init__(
         self,

--- a/custom_components/ticktick/application_credentials.py
+++ b/custom_components/ticktick/application_credentials.py
@@ -2,13 +2,53 @@
 
 from homeassistant.components.application_credentials import AuthorizationServer
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import config_entry_oauth2_flow
 
-from .const import OAUTH2_AUTHORIZE, OAUTH2_TOKEN
+from .const import DEFAULT_REGION, REGIONS
+
+
+class RegionalOAuth2Implementation(
+    config_entry_oauth2_flow.LocalOAuth2Implementation
+):
+    """OAuth implementation using the endpoints for a selected region."""
+
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        implementation: config_entry_oauth2_flow.AbstractOAuth2Implementation,
+        region: str,
+    ) -> None:
+        """Initialize the regional implementation."""
+        region_config = REGIONS.get(region, REGIONS[DEFAULT_REGION])
+        super().__init__(
+            hass,
+            implementation.domain,
+            implementation.client_id,
+            implementation.client_secret,
+            region_config["authorize_url"],
+            region_config["token_url"],
+        )
+        self._name = implementation.name
+
+    @property
+    def name(self) -> str:
+        """Return the credential name."""
+        return self._name
 
 
 async def async_get_authorization_server(hass: HomeAssistant) -> AuthorizationServer:
     """Return authorization server."""
+    region = REGIONS[DEFAULT_REGION]
     return AuthorizationServer(
-        authorize_url=OAUTH2_AUTHORIZE,
-        token_url=OAUTH2_TOKEN,
+        authorize_url=region["authorize_url"],
+        token_url=region["token_url"],
     )
+
+
+def regionalize_implementation(
+    hass: HomeAssistant,
+    implementation: config_entry_oauth2_flow.AbstractOAuth2Implementation,
+    region: str,
+) -> RegionalOAuth2Implementation:
+    """Return an OAuth implementation for the selected region."""
+    return RegionalOAuth2Implementation(hass, implementation, region)

--- a/custom_components/ticktick/application_credentials.py
+++ b/custom_components/ticktick/application_credentials.py
@@ -55,4 +55,6 @@ def regionalize_implementation(
     region: str,
 ) -> RegionalOAuth2Implementation:
     """Return an OAuth implementation for the selected region."""
+    if isinstance(implementation, RegionalOAuth2Implementation):
+        return implementation
     return RegionalOAuth2Implementation(hass, implementation, region)

--- a/custom_components/ticktick/config_flow.py
+++ b/custom_components/ticktick/config_flow.py
@@ -7,19 +7,8 @@ from homeassistant.config_entries import ConfigEntry, OptionsFlow
 from homeassistant.core import callback
 from homeassistant.helpers import config_entry_oauth2_flow
 
-from .const import CONF_API_ENDPOINT, DEFAULT_API_ENDPOINT, DOMAIN
-
-
-def _validate_api_endpoint(value: str) -> str:
-    """Validate that an API endpoint uses HTTPS."""
-    if not value.startswith("https://"):
-        raise vol.Invalid(
-            "API endpoint must use HTTPS protocol (e.g., https://api.example.com)"
-        )
-    return value
-
-
-API_ENDPOINT_SCHEMA = vol.All(vol.Url(), _validate_api_endpoint)
+from .application_credentials import regionalize_implementation
+from .const import CONF_REGION, DEFAULT_REGION, DOMAIN, REGIONS
 
 
 class OAuth2FlowHandler(
@@ -32,67 +21,42 @@ class OAuth2FlowHandler(
     def __init__(self) -> None:
         """Initialize the config flow."""
         super().__init__()
-        self._api_endpoint = DEFAULT_API_ENDPOINT
+        self._region = DEFAULT_REGION
 
     async def async_step_user(self, user_input=None):
-        """Configure the API endpoint before authentication."""
+        """Select the TickTick service before authentication."""
         if user_input is not None:
-            self._api_endpoint = user_input[CONF_API_ENDPOINT]
+            self._region = user_input[CONF_REGION]
             return await self.async_step_pick_implementation()
 
         return self.async_show_form(
             step_id="user",
             data_schema=vol.Schema(
                 {
-                    vol.Required(
-                        CONF_API_ENDPOINT, default=DEFAULT_API_ENDPOINT
-                    ): API_ENDPOINT_SCHEMA,
+                    vol.Required(CONF_REGION, default=DEFAULT_REGION): vol.In(
+                        {key: value["name"] for key, value in REGIONS.items()}
+                    )
                 }
             ),
         )
 
+    async def async_step_pick_implementation(self, user_input=None):
+        """Select credentials and apply the selected service endpoints."""
+        result = await super().async_step_pick_implementation(user_input)
+        if self.flow_impl is not None:
+            self.flow_impl = regionalize_implementation(
+                self.hass, self.flow_impl, self._region
+            )
+        return result
+
     async def async_oauth_create_entry(self, data):
-        """Create an entry with the selected API endpoint."""
+        """Create an entry with the selected region."""
         return self.async_create_entry(
             title=self.flow_impl.name,
-            data=data,
-            options={CONF_API_ENDPOINT: self._api_endpoint},
+            data={**data, CONF_REGION: self._region},
         )
 
     @property
     def logger(self) -> logging.Logger:
         """Return logger."""
         return logging.getLogger(__name__)
-
-    @staticmethod
-    @callback
-    def async_get_options_flow(config_entry: ConfigEntry) -> OptionsFlow:
-        """Return the options flow."""
-        return OptionsFlowHandler(config_entry)
-
-
-class OptionsFlowHandler(OptionsFlow):
-    """Handle TickTick options."""
-
-    def __init__(self, config_entry: ConfigEntry) -> None:
-        """Initialize the options flow."""
-        self._config_entry = config_entry
-
-    async def async_step_init(self, user_input=None):
-        """Manage the TickTick options."""
-        if user_input is not None:
-            return self.async_create_entry(data=user_input)
-
-        return self.async_show_form(
-            step_id="init",
-            data_schema=vol.Schema(
-                {
-                    vol.Required(
-                        CONF_API_ENDPOINT,
-                        default=self._config_entry.options.get(
-                            CONF_API_ENDPOINT, DEFAULT_API_ENDPOINT
-                        ),
-                    ): API_ENDPOINT_SCHEMA,
-                }
-            ),
-        )

--- a/custom_components/ticktick/config_flow.py
+++ b/custom_components/ticktick/config_flow.py
@@ -2,9 +2,12 @@
 
 import logging
 
+import voluptuous as vol
+from homeassistant.config_entries import ConfigEntry, OptionsFlow
+from homeassistant.core import callback
 from homeassistant.helpers import config_entry_oauth2_flow
 
-from .const import DOMAIN
+from .const import CONF_API_ENDPOINT, DEFAULT_API_ENDPOINT, DOMAIN
 
 
 class OAuth2FlowHandler(
@@ -18,3 +21,32 @@ class OAuth2FlowHandler(
     def logger(self) -> logging.Logger:
         """Return logger."""
         return logging.getLogger(__name__)
+
+    @staticmethod
+    @callback
+    def async_get_options_flow(config_entry: ConfigEntry) -> OptionsFlow:
+        """Return the options flow."""
+        return OptionsFlowHandler()
+
+
+class OptionsFlowHandler(OptionsFlow):
+    """Handle TickTick options."""
+
+    async def async_step_init(self, user_input=None):
+        """Manage the TickTick options."""
+        if user_input is not None:
+            return self.async_create_entry(data=user_input)
+
+        return self.async_show_form(
+            step_id="init",
+            data_schema=vol.Schema(
+                {
+                    vol.Required(
+                        CONF_API_ENDPOINT,
+                        default=self.config_entry.options.get(
+                            CONF_API_ENDPOINT, DEFAULT_API_ENDPOINT
+                        ),
+                    ): str,
+                }
+            ),
+        )

--- a/custom_components/ticktick/config_flow.py
+++ b/custom_components/ticktick/config_flow.py
@@ -17,6 +17,36 @@ class OAuth2FlowHandler(
 
     DOMAIN = DOMAIN
 
+    def __init__(self) -> None:
+        """Initialize the config flow."""
+        super().__init__()
+        self._api_endpoint = DEFAULT_API_ENDPOINT
+
+    async def async_step_user(self, user_input=None):
+        """Configure the API endpoint before authentication."""
+        if user_input is not None:
+            self._api_endpoint = user_input[CONF_API_ENDPOINT]
+            return await self.async_step_pick_implementation()
+
+        return self.async_show_form(
+            step_id="user",
+            data_schema=vol.Schema(
+                {
+                    vol.Required(
+                        CONF_API_ENDPOINT, default=DEFAULT_API_ENDPOINT
+                    ): str,
+                }
+            ),
+        )
+
+    async def async_oauth_create_entry(self, data):
+        """Create an entry with the selected API endpoint."""
+        return self.async_create_entry(
+            title=self.flow_impl.name,
+            data=data,
+            options={CONF_API_ENDPOINT: self._api_endpoint},
+        )
+
     @property
     def logger(self) -> logging.Logger:
         """Return logger."""

--- a/custom_components/ticktick/config_flow.py
+++ b/custom_components/ticktick/config_flow.py
@@ -3,6 +3,7 @@
 import logging
 
 import voluptuous as vol
+from homeassistant import config_entries
 from homeassistant.helpers import config_entry_oauth2_flow
 
 from .application_credentials import regionalize_implementation
@@ -21,8 +22,17 @@ class OAuth2FlowHandler(
         super().__init__()
         self._region = DEFAULT_REGION
 
-    async def async_step_user(self, user_input=None):
-        """Select the TickTick service before authentication."""
+    async def async_step_user(
+        self, user_input: dict | None = None
+    ) -> config_entries.ConfigFlowResult:
+        """Select the service before authentication.
+
+        Args:
+            user_input: The selected service, or None when showing the form.
+
+        Returns:
+            The next configuration flow step.
+        """
         if user_input is not None:
             self._region = user_input[CONF_REGION]
             return await self.async_step_pick_implementation()
@@ -45,8 +55,17 @@ class OAuth2FlowHandler(
         )
         return await super().async_generate_authorize_url()
 
-    async def async_oauth_create_entry(self, data):
-        """Create an entry with the selected region."""
+    async def async_oauth_create_entry(
+        self, data: dict
+    ) -> config_entries.ConfigFlowResult:
+        """Create an entry with the selected region.
+
+        Args:
+            data: OAuth token data and the selected credential implementation.
+
+        Returns:
+            The created config entry.
+        """
         return self.async_create_entry(
             title=self.flow_impl.name,
             data={**data, CONF_REGION: self._region},

--- a/custom_components/ticktick/config_flow.py
+++ b/custom_components/ticktick/config_flow.py
@@ -53,7 +53,10 @@ class OAuth2FlowHandler(
 
     async def async_generate_authorize_url(self) -> str:
         """Generate an authorize URL for the selected service."""
-        if not isinstance(self.flow_impl, RegionalOAuth2Implementation):
+        if not (
+            isinstance(self.flow_impl, RegionalOAuth2Implementation)
+            and self.flow_impl.region == self._region
+        ):
             self.flow_impl = regionalize_implementation(
                 self.hass, self.flow_impl, self._region
             )

--- a/custom_components/ticktick/config_flow.py
+++ b/custom_components/ticktick/config_flow.py
@@ -13,7 +13,9 @@ from .const import CONF_API_ENDPOINT, DEFAULT_API_ENDPOINT, DOMAIN
 def _validate_api_endpoint(value: str) -> str:
     """Validate that an API endpoint uses HTTPS."""
     if not value.startswith("https://"):
-        raise vol.Invalid("API endpoint must use HTTPS")
+        raise vol.Invalid(
+            "API endpoint must use HTTPS protocol (e.g., https://api.example.com)"
+        )
     return value
 
 

--- a/custom_components/ticktick/config_flow.py
+++ b/custom_components/ticktick/config_flow.py
@@ -6,10 +6,7 @@ import voluptuous as vol
 from homeassistant import config_entries
 from homeassistant.helpers import config_entry_oauth2_flow
 
-from .application_credentials import (
-    RegionalOAuth2Implementation,
-    regionalize_implementation,
-)
+from .application_credentials import regionalize_implementation
 from .const import CONF_REGION, DEFAULT_REGION, DOMAIN, REGIONS
 
 
@@ -53,13 +50,9 @@ class OAuth2FlowHandler(
 
     async def async_generate_authorize_url(self) -> str:
         """Generate an authorize URL for the selected service."""
-        if not (
-            isinstance(self.flow_impl, RegionalOAuth2Implementation)
-            and self.flow_impl.region == self._region
-        ):
-            self.flow_impl = regionalize_implementation(
-                self.hass, self.flow_impl, self._region
-            )
+        self.flow_impl = regionalize_implementation(
+            self.hass, self.flow_impl, self._region
+        )
         return await super().async_generate_authorize_url()
 
     async def async_oauth_create_entry(

--- a/custom_components/ticktick/config_flow.py
+++ b/custom_components/ticktick/config_flow.py
@@ -9,7 +9,7 @@ from homeassistant.helpers import config_entry_oauth2_flow
 
 from .const import CONF_API_ENDPOINT, DEFAULT_API_ENDPOINT, DOMAIN
 
-API_ENDPOINT_SCHEMA = vol.All(vol.Url(), vol.Match(r"^https?://"))
+API_ENDPOINT_SCHEMA = vol.All(vol.Url(), vol.Match(r"^https://"))
 
 
 class OAuth2FlowHandler(

--- a/custom_components/ticktick/config_flow.py
+++ b/custom_components/ticktick/config_flow.py
@@ -6,7 +6,10 @@ import voluptuous as vol
 from homeassistant import config_entries
 from homeassistant.helpers import config_entry_oauth2_flow
 
-from .application_credentials import regionalize_implementation
+from .application_credentials import (
+    RegionalOAuth2Implementation,
+    regionalize_implementation,
+)
 from .const import CONF_REGION, DEFAULT_REGION, DOMAIN, REGIONS
 
 
@@ -50,9 +53,10 @@ class OAuth2FlowHandler(
 
     async def async_generate_authorize_url(self) -> str:
         """Generate an authorize URL for the selected service."""
-        self.flow_impl = regionalize_implementation(
-            self.hass, self.flow_impl, self._region
-        )
+        if not isinstance(self.flow_impl, RegionalOAuth2Implementation):
+            self.flow_impl = regionalize_implementation(
+                self.hass, self.flow_impl, self._region
+            )
         return await super().async_generate_authorize_url()
 
     async def async_oauth_create_entry(

--- a/custom_components/ticktick/config_flow.py
+++ b/custom_components/ticktick/config_flow.py
@@ -9,6 +9,8 @@ from homeassistant.helpers import config_entry_oauth2_flow
 
 from .const import CONF_API_ENDPOINT, DEFAULT_API_ENDPOINT, DOMAIN
 
+API_ENDPOINT_SCHEMA = vol.All(vol.Url(), vol.Match(r"^https?://"))
+
 
 class OAuth2FlowHandler(
     config_entry_oauth2_flow.AbstractOAuth2FlowHandler, domain=DOMAIN
@@ -34,7 +36,7 @@ class OAuth2FlowHandler(
                 {
                     vol.Required(
                         CONF_API_ENDPOINT, default=DEFAULT_API_ENDPOINT
-                    ): vol.Url(),
+                    ): API_ENDPOINT_SCHEMA,
                 }
             ),
         )
@@ -80,7 +82,7 @@ class OptionsFlowHandler(OptionsFlow):
                         default=self._config_entry.options.get(
                             CONF_API_ENDPOINT, DEFAULT_API_ENDPOINT
                         ),
-                    ): vol.Url(),
+                    ): API_ENDPOINT_SCHEMA,
                 }
             ),
         )

--- a/custom_components/ticktick/config_flow.py
+++ b/custom_components/ticktick/config_flow.py
@@ -26,11 +26,15 @@ class OAuth2FlowHandler(
     @callback
     def async_get_options_flow(config_entry: ConfigEntry) -> OptionsFlow:
         """Return the options flow."""
-        return OptionsFlowHandler()
+        return OptionsFlowHandler(config_entry)
 
 
 class OptionsFlowHandler(OptionsFlow):
     """Handle TickTick options."""
+
+    def __init__(self, config_entry: ConfigEntry) -> None:
+        """Initialize the options flow."""
+        self._config_entry = config_entry
 
     async def async_step_init(self, user_input=None):
         """Manage the TickTick options."""
@@ -43,7 +47,7 @@ class OptionsFlowHandler(OptionsFlow):
                 {
                     vol.Required(
                         CONF_API_ENDPOINT,
-                        default=self.config_entry.options.get(
+                        default=self._config_entry.options.get(
                             CONF_API_ENDPOINT, DEFAULT_API_ENDPOINT
                         ),
                     ): str,

--- a/custom_components/ticktick/config_flow.py
+++ b/custom_components/ticktick/config_flow.py
@@ -34,7 +34,7 @@ class OAuth2FlowHandler(
                 {
                     vol.Required(
                         CONF_API_ENDPOINT, default=DEFAULT_API_ENDPOINT
-                    ): str,
+                    ): vol.Url(),
                 }
             ),
         )
@@ -80,7 +80,7 @@ class OptionsFlowHandler(OptionsFlow):
                         default=self._config_entry.options.get(
                             CONF_API_ENDPOINT, DEFAULT_API_ENDPOINT
                         ),
-                    ): str,
+                    ): vol.Url(),
                 }
             ),
         )

--- a/custom_components/ticktick/config_flow.py
+++ b/custom_components/ticktick/config_flow.py
@@ -9,7 +9,15 @@ from homeassistant.helpers import config_entry_oauth2_flow
 
 from .const import CONF_API_ENDPOINT, DEFAULT_API_ENDPOINT, DOMAIN
 
-API_ENDPOINT_SCHEMA = vol.All(vol.Url(), vol.Match(r"^https://"))
+
+def _validate_api_endpoint(value: str) -> str:
+    """Validate that an API endpoint uses HTTPS."""
+    if not value.startswith("https://"):
+        raise vol.Invalid("API endpoint must use HTTPS")
+    return value
+
+
+API_ENDPOINT_SCHEMA = vol.All(vol.Url(), _validate_api_endpoint)
 
 
 class OAuth2FlowHandler(

--- a/custom_components/ticktick/config_flow.py
+++ b/custom_components/ticktick/config_flow.py
@@ -3,8 +3,6 @@
 import logging
 
 import voluptuous as vol
-from homeassistant.config_entries import ConfigEntry, OptionsFlow
-from homeassistant.core import callback
 from homeassistant.helpers import config_entry_oauth2_flow
 
 from .application_credentials import regionalize_implementation
@@ -40,14 +38,12 @@ class OAuth2FlowHandler(
             ),
         )
 
-    async def async_step_pick_implementation(self, user_input=None):
-        """Select credentials and apply the selected service endpoints."""
-        result = await super().async_step_pick_implementation(user_input)
-        if self.flow_impl is not None:
-            self.flow_impl = regionalize_implementation(
-                self.hass, self.flow_impl, self._region
-            )
-        return result
+    async def async_generate_authorize_url(self) -> str:
+        """Generate an authorize URL for the selected service."""
+        self.flow_impl = regionalize_implementation(
+            self.hass, self.flow_impl, self._region
+        )
+        return await super().async_generate_authorize_url()
 
     async def async_oauth_create_entry(self, data):
         """Create an entry with the selected region."""

--- a/custom_components/ticktick/const.py
+++ b/custom_components/ticktick/const.py
@@ -23,7 +23,6 @@ REGIONS = {
     },
 }
 DEFAULT_REGION = REGION_TICKTICK
-API = ""
 
 # === Parameters === #
 PROJECT_ID = "projectId"

--- a/custom_components/ticktick/const.py
+++ b/custom_components/ticktick/const.py
@@ -2,11 +2,26 @@
 
 DOMAIN = "ticktick"
 
-OAUTH2_AUTHORIZE = "https://ticktick.com/oauth/authorize"
-OAUTH2_TOKEN = "https://ticktick.com/oauth/token"
-DEFAULT_API_ENDPOINT = "https://api.ticktick.com"
-API = "open/v1"
-CONF_API_ENDPOINT = "api_endpoint"
+CONF_REGION = "region"
+REGION_TICKTICK = "ticktick"
+REGION_DIDA365 = "dida365"
+
+REGIONS = {
+    REGION_TICKTICK: {
+        "name": "TickTick",
+        "authorize_url": "https://ticktick.com/oauth/authorize",
+        "token_url": "https://ticktick.com/oauth/token",
+        "api_base_url": "https://api.ticktick.com/open/v1",
+    },
+    REGION_DIDA365: {
+        "name": "Dida365",
+        "authorize_url": "https://dida365.com/oauth/authorize",
+        "token_url": "https://dida365.com/oauth/token",
+        "api_base_url": "https://api.dida365.com/open/v1",
+    },
+}
+DEFAULT_REGION = REGION_TICKTICK
+API = ""
 
 # === Parameters === #
 PROJECT_ID = "projectId"
@@ -15,12 +30,12 @@ TASK_ID = "taskId"
 # === Endpoints === #
 
 # === Task Scope ===
-GET_TASK = f"{API}/project/{{{PROJECT_ID}}}/task/{{{TASK_ID}}}"
-CREATE_TASK = f"{API}/task"
-UPDATE_TASK = f"{API}/task/{{{TASK_ID}}}"
-COMPLETE_TASK = f"{API}/project/{{{PROJECT_ID}}}/task/{{{TASK_ID}}}/complete"
+GET_TASK = f"project/{{{PROJECT_ID}}}/task/{{{TASK_ID}}}"
+CREATE_TASK = "task"
+UPDATE_TASK = f"task/{{{TASK_ID}}}"
+COMPLETE_TASK = f"project/{{{PROJECT_ID}}}/task/{{{TASK_ID}}}/complete"
 DELETE_TASK = GET_TASK
 
 # === Project Scope ===
-GET_PROJECTS = f"{API}/project"
-GET_PROJECTS_WITH_TASKS = f"{API}/project/{{{PROJECT_ID}}}/data"
+GET_PROJECTS = "project"
+GET_PROJECTS_WITH_TASKS = f"project/{{{PROJECT_ID}}}/data"

--- a/custom_components/ticktick/const.py
+++ b/custom_components/ticktick/const.py
@@ -12,14 +12,12 @@ REGIONS = {
         "authorize_url": "https://ticktick.com/oauth/authorize",
         "token_url": "https://ticktick.com/oauth/token",
         "api_base_url": "https://api.ticktick.com/open/v1",
-        "developer_url": "https://developer.ticktick.com/manage",
     },
     REGION_DIDA365: {
         "name": "Dida365 (China region)",
         "authorize_url": "https://dida365.com/oauth/authorize",
         "token_url": "https://dida365.com/oauth/token",
         "api_base_url": "https://api.dida365.com/open/v1",
-        "developer_url": "https://developer.dida365.com/manage",
     },
 }
 DEFAULT_REGION = REGION_TICKTICK

--- a/custom_components/ticktick/const.py
+++ b/custom_components/ticktick/const.py
@@ -8,14 +8,14 @@ REGION_DIDA365 = "dida365"
 
 REGIONS = {
     REGION_TICKTICK: {
-        "name": "TickTick",
+        "name": "TickTick (international)",
         "authorize_url": "https://ticktick.com/oauth/authorize",
         "token_url": "https://ticktick.com/oauth/token",
         "api_base_url": "https://api.ticktick.com/open/v1",
         "developer_url": "https://developer.ticktick.com/manage",
     },
     REGION_DIDA365: {
-        "name": "Dida365",
+        "name": "Dida365 (China region)",
         "authorize_url": "https://dida365.com/oauth/authorize",
         "token_url": "https://dida365.com/oauth/token",
         "api_base_url": "https://api.dida365.com/open/v1",

--- a/custom_components/ticktick/const.py
+++ b/custom_components/ticktick/const.py
@@ -6,7 +6,7 @@ OAUTH2_AUTHORIZE = "https://ticktick.com/oauth/authorize"
 OAUTH2_TOKEN = "https://ticktick.com/oauth/token"
 DEFAULT_API_ENDPOINT = "https://api.ticktick.com"
 API = "open/v1"
-BASE_API_URL = f"{API}"
+BASE_API_URL = API
 CONF_API_ENDPOINT = "api_endpoint"
 
 # === Parameters === #

--- a/custom_components/ticktick/const.py
+++ b/custom_components/ticktick/const.py
@@ -6,7 +6,7 @@ OAUTH2_AUTHORIZE = "https://ticktick.com/oauth/authorize"
 OAUTH2_TOKEN = "https://ticktick.com/oauth/token"
 DEFAULT_API_ENDPOINT = "https://api.ticktick.com"
 API = "open/v1"
-BASE_API_URL = API
+API_PATH = API
 CONF_API_ENDPOINT = "api_endpoint"
 
 # === Parameters === #
@@ -16,12 +16,12 @@ TASK_ID = "taskId"
 # === Endpoints === #
 
 # === Task Scope ===
-GET_TASK = f"{BASE_API_URL}/project/{{{PROJECT_ID}}}/task/{{{TASK_ID}}}"
-CREATE_TASK = f"{BASE_API_URL}/task"
-UPDATE_TASK = f"{BASE_API_URL}/task/{{{TASK_ID}}}"
-COMPLETE_TASK = f"{BASE_API_URL}/project/{{{PROJECT_ID}}}/task/{{{TASK_ID}}}/complete"
+GET_TASK = f"{API_PATH}/project/{{{PROJECT_ID}}}/task/{{{TASK_ID}}}"
+CREATE_TASK = f"{API_PATH}/task"
+UPDATE_TASK = f"{API_PATH}/task/{{{TASK_ID}}}"
+COMPLETE_TASK = f"{API_PATH}/project/{{{PROJECT_ID}}}/task/{{{TASK_ID}}}/complete"
 DELETE_TASK = GET_TASK
 
 # === Project Scope ===
-GET_PROJECTS = f"{BASE_API_URL}/project"
-GET_PROJECTS_WITH_TASKS = f"{BASE_API_URL}/project/{{{PROJECT_ID}}}/data"
+GET_PROJECTS = f"{API_PATH}/project"
+GET_PROJECTS_WITH_TASKS = f"{API_PATH}/project/{{{PROJECT_ID}}}/data"

--- a/custom_components/ticktick/const.py
+++ b/custom_components/ticktick/const.py
@@ -23,6 +23,7 @@ REGIONS = {
     },
 }
 DEFAULT_REGION = REGION_TICKTICK
+DEFAULT_API_BASE_URL = REGIONS[DEFAULT_REGION]["api_base_url"]
 
 # === Parameters === #
 PROJECT_ID = "projectId"

--- a/custom_components/ticktick/const.py
+++ b/custom_components/ticktick/const.py
@@ -12,12 +12,14 @@ REGIONS = {
         "authorize_url": "https://ticktick.com/oauth/authorize",
         "token_url": "https://ticktick.com/oauth/token",
         "api_base_url": "https://api.ticktick.com/open/v1",
+        "developer_url": "https://developer.ticktick.com/manage",
     },
     REGION_DIDA365: {
         "name": "Dida365",
         "authorize_url": "https://dida365.com/oauth/authorize",
         "token_url": "https://dida365.com/oauth/token",
         "api_base_url": "https://api.dida365.com/open/v1",
+        "developer_url": "https://developer.dida365.com/manage",
     },
 }
 DEFAULT_REGION = REGION_TICKTICK

--- a/custom_components/ticktick/const.py
+++ b/custom_components/ticktick/const.py
@@ -4,9 +4,10 @@ DOMAIN = "ticktick"
 
 OAUTH2_AUTHORIZE = "https://ticktick.com/oauth/authorize"
 OAUTH2_TOKEN = "https://ticktick.com/oauth/token"
-TICKTICK_HOST = "api.ticktick.com"
+DEFAULT_API_ENDPOINT = "https://api.ticktick.com"
 API = "open/v1"
-BASE_API_URL = f"{TICKTICK_HOST}/{API}"
+BASE_API_URL = f"{API}"
+CONF_API_ENDPOINT = "api_endpoint"
 
 # === Parameters === #
 PROJECT_ID = "projectId"

--- a/custom_components/ticktick/const.py
+++ b/custom_components/ticktick/const.py
@@ -6,7 +6,6 @@ OAUTH2_AUTHORIZE = "https://ticktick.com/oauth/authorize"
 OAUTH2_TOKEN = "https://ticktick.com/oauth/token"
 DEFAULT_API_ENDPOINT = "https://api.ticktick.com"
 API = "open/v1"
-API_PATH = API
 CONF_API_ENDPOINT = "api_endpoint"
 
 # === Parameters === #
@@ -16,12 +15,12 @@ TASK_ID = "taskId"
 # === Endpoints === #
 
 # === Task Scope ===
-GET_TASK = f"{API_PATH}/project/{{{PROJECT_ID}}}/task/{{{TASK_ID}}}"
-CREATE_TASK = f"{API_PATH}/task"
-UPDATE_TASK = f"{API_PATH}/task/{{{TASK_ID}}}"
-COMPLETE_TASK = f"{API_PATH}/project/{{{PROJECT_ID}}}/task/{{{TASK_ID}}}/complete"
+GET_TASK = f"{API}/project/{{{PROJECT_ID}}}/task/{{{TASK_ID}}}"
+CREATE_TASK = f"{API}/task"
+UPDATE_TASK = f"{API}/task/{{{TASK_ID}}}"
+COMPLETE_TASK = f"{API}/project/{{{PROJECT_ID}}}/task/{{{TASK_ID}}}/complete"
 DELETE_TASK = GET_TASK
 
 # === Project Scope ===
-GET_PROJECTS = f"{API_PATH}/project"
-GET_PROJECTS_WITH_TASKS = f"{API_PATH}/project/{{{PROJECT_ID}}}/data"
+GET_PROJECTS = f"{API}/project"
+GET_PROJECTS_WITH_TASKS = f"{API}/project/{{{PROJECT_ID}}}/data"

--- a/custom_components/ticktick/strings.json
+++ b/custom_components/ticktick/strings.json
@@ -19,6 +19,17 @@
         },
         "create_entry": {
             "default": "[%key:common::config_flow::create_entry::authenticated%]"
+        },
+        "options": {
+            "step": {
+                "init": {
+                    "title": "API endpoint",
+                    "description": "Configure the TickTick-compatible API endpoint.",
+                    "data": {
+                        "api_endpoint": "API endpoint"
+                    }
+                }
+            }
         }
     }
 }

--- a/custom_components/ticktick/strings.json
+++ b/custom_components/ticktick/strings.json
@@ -1,6 +1,13 @@
 {
     "config": {
         "step": {
+            "user": {
+                "title": "API endpoint",
+                "description": "Configure the TickTick-compatible API endpoint.",
+                "data": {
+                    "api_endpoint": "API endpoint"
+                }
+            },
             "pick_implementation": {
                 "title": "[%key:common::config_flow::title::oauth2_pick_implementation%]"
             }

--- a/custom_components/ticktick/strings.json
+++ b/custom_components/ticktick/strings.json
@@ -3,7 +3,7 @@
         "step": {
             "user": {
                 "title": "Service",
-                "description": "Select TickTick or Dida365. Developer credentials are specific to each service and cannot be shared.",
+                "description": "Select TickTick (international) or Dida365 (China region). Each service uses its own OAuth and API endpoints, and its developer credentials cannot be shared with the other service.",
                 "data": {
                     "region": "Service"
                 }

--- a/custom_components/ticktick/strings.json
+++ b/custom_components/ticktick/strings.json
@@ -2,10 +2,10 @@
     "config": {
         "step": {
             "user": {
-                "title": "API endpoint",
-                "description": "Configure the TickTick-compatible API endpoint.",
+                "title": "Service",
+                "description": "Select TickTick or Dida365. Developer credentials are specific to each service and cannot be shared.",
                 "data": {
-                    "api_endpoint": "API endpoint"
+                    "region": "Service"
                 }
             },
             "pick_implementation": {
@@ -26,17 +26,6 @@
         },
         "create_entry": {
             "default": "[%key:common::config_flow::create_entry::authenticated%]"
-        },
-        "options": {
-            "step": {
-                "init": {
-                    "title": "API endpoint",
-                    "description": "Configure the TickTick-compatible API endpoint.",
-                    "data": {
-                        "api_endpoint": "API endpoint"
-                    }
-                }
-            }
         }
     }
 }

--- a/custom_components/ticktick/ticktick_api_python/ticktick_api.py
+++ b/custom_components/ticktick/ticktick_api_python/ticktick_api.py
@@ -9,6 +9,7 @@ from custom_components.ticktick.const import (
     GET_PROJECTS_WITH_TASKS,
     GET_TASK,
     UPDATE_TASK,
+    DEFAULT_API_BASE_URL,
 )
 
 from .models.project import Kind, Project
@@ -23,7 +24,7 @@ class TickTickAPIClient:
         self,
         access_token: str,
         session: ClientSession,
-        api_base_url: str,
+        api_base_url: str = DEFAULT_API_BASE_URL,
     ) -> None:
         """Initialize the TickTick API client."""
         self._headers = {"Authorization": f"Bearer {access_token}"}

--- a/custom_components/ticktick/ticktick_api_python/ticktick_api.py
+++ b/custom_components/ticktick/ticktick_api_python/ticktick_api.py
@@ -1,7 +1,7 @@
 """TickTick API Client."""
 
 from aiohttp import ClientResponse, ClientSession
-from ..const import (
+from custom_components.ticktick.const import (
     COMPLETE_TASK,
     CREATE_TASK,
     DELETE_TASK,

--- a/custom_components/ticktick/ticktick_api_python/ticktick_api.py
+++ b/custom_components/ticktick/ticktick_api_python/ticktick_api.py
@@ -9,6 +9,7 @@ from custom_components.ticktick.const import (
     GET_PROJECTS_WITH_TASKS,
     GET_TASK,
     UPDATE_TASK,
+    DEFAULT_API_ENDPOINT,
 )
 
 from .models.project import Kind, Project
@@ -20,7 +21,10 @@ class TickTickAPIClient:
     """TickTick API Client."""
 
     def __init__(
-        self, access_token: str, session: ClientSession, api_endpoint: str
+        self,
+        access_token: str,
+        session: ClientSession,
+        api_endpoint: str = DEFAULT_API_ENDPOINT,
     ) -> None:
         """Initialize the TickTick API client."""
         self._headers = {"Authorization": f"Bearer {access_token}"}

--- a/custom_components/ticktick/ticktick_api_python/ticktick_api.py
+++ b/custom_components/ticktick/ticktick_api_python/ticktick_api.py
@@ -31,6 +31,10 @@ class TickTickAPIClient:
         self._session = session
         self._api_endpoint = api_endpoint.rstrip("/")
 
+    def _url(self, path: str) -> str:
+        """Build a URL from the configured endpoint and API path."""
+        return f"{self._api_endpoint}/{path.lstrip('/')}"
+
     # === Task Scope ===
     async def get_task(
         self, projectId: str, taskId: str, returnAsJson: bool = False
@@ -95,14 +99,14 @@ class TickTickAPIClient:
 
     async def _get(self, url: str) -> ClientResponse:
         response = await self._session.get(
-            f"{self._api_endpoint}/{url}", headers=self._headers
+            self._url(url), headers=self._headers
         )
         return await self._get_response(response)
 
     async def _post(self, url: str, json_body: str | None = None) -> ClientResponse:
         self._headers["Content-Type"] = "application/json"
         response = await self._session.post(
-            f"{self._api_endpoint}/{url}",
+            self._url(url),
             headers=self._headers,
             data=json_body if json_body else None,
         )
@@ -110,7 +114,7 @@ class TickTickAPIClient:
 
     async def _delete(self, url: str) -> ClientResponse:
         response = await self._session.delete(
-            f"{self._api_endpoint}/{url}", headers=self._headers
+            self._url(url), headers=self._headers
         )
         return await self._get_response(response)
 

--- a/custom_components/ticktick/ticktick_api_python/ticktick_api.py
+++ b/custom_components/ticktick/ticktick_api_python/ticktick_api.py
@@ -19,10 +19,13 @@ from .models.task import Task
 class TickTickAPIClient:
     """TickTick API Client."""
 
-    def __init__(self, access_token: str, session: ClientSession) -> None:
+    def __init__(
+        self, access_token: str, session: ClientSession, api_endpoint: str
+    ) -> None:
         """Initialize the TickTick API client."""
         self._headers = {"Authorization": f"Bearer {access_token}"}
         self._session = session
+        self._api_endpoint = api_endpoint.rstrip("/")
 
     # === Task Scope ===
     async def get_task(
@@ -87,20 +90,24 @@ class TickTickAPIClient:
         return ProjectWithTasks.from_dict(response)
 
     async def _get(self, url: str) -> ClientResponse:
-        response = await self._session.get(f"https://{url}", headers=self._headers)
+        response = await self._session.get(
+            f"{self._api_endpoint}/{url}", headers=self._headers
+        )
         return await self._get_response(response)
 
     async def _post(self, url: str, json_body: str | None = None) -> ClientResponse:
         self._headers["Content-Type"] = "application/json"
         response = await self._session.post(
-            f"https://{url}",
+            f"{self._api_endpoint}/{url}",
             headers=self._headers,
             data=json_body if json_body else None,
         )
         return await self._get_response(response)
 
     async def _delete(self, url: str) -> ClientResponse:
-        response = await self._session.delete(f"https://{url}", headers=self._headers)
+        response = await self._session.delete(
+            f"{self._api_endpoint}/{url}", headers=self._headers
+        )
         return await self._get_response(response)
 
     async def _get_response(

--- a/custom_components/ticktick/ticktick_api_python/ticktick_api.py
+++ b/custom_components/ticktick/ticktick_api_python/ticktick_api.py
@@ -1,7 +1,7 @@
 """TickTick API Client."""
 
 from aiohttp import ClientResponse, ClientSession
-from custom_components.ticktick.const import (
+from ..const import (
     COMPLETE_TASK,
     CREATE_TASK,
     DELETE_TASK,
@@ -9,7 +9,6 @@ from custom_components.ticktick.const import (
     GET_PROJECTS_WITH_TASKS,
     GET_TASK,
     UPDATE_TASK,
-    DEFAULT_API_ENDPOINT,
 )
 
 from .models.project import Kind, Project
@@ -24,16 +23,16 @@ class TickTickAPIClient:
         self,
         access_token: str,
         session: ClientSession,
-        api_endpoint: str = DEFAULT_API_ENDPOINT,
+        api_base_url: str,
     ) -> None:
         """Initialize the TickTick API client."""
         self._headers = {"Authorization": f"Bearer {access_token}"}
         self._session = session
-        self._api_endpoint = api_endpoint.rstrip("/")
+        self._api_base_url = api_base_url.rstrip("/")
 
     def _url(self, path: str) -> str:
         """Build a URL from the configured endpoint and API path."""
-        return f"{self._api_endpoint}/{path.lstrip('/')}"
+        return f"{self._api_base_url}/{path.lstrip('/')}"
 
     # === Task Scope ===
     async def get_task(

--- a/custom_components/ticktick/translations/en.json
+++ b/custom_components/ticktick/translations/en.json
@@ -15,23 +15,12 @@
         "create_entry": {
             "default": "Successfully authenticated"
         },
-        "options": {
-            "step": {
-                "init": {
-                    "title": "API endpoint",
-                    "description": "Configure the TickTick-compatible API endpoint.",
-                    "data": {
-                        "api_endpoint": "API endpoint"
-                    }
-                }
-            }
-        },
         "step": {
             "user": {
-                "title": "API endpoint",
-                "description": "Configure the TickTick-compatible API endpoint.",
+                "title": "Service",
+                "description": "Select TickTick or Dida365. Developer credentials are specific to each service and cannot be shared.",
                 "data": {
-                    "api_endpoint": "API endpoint"
+                    "region": "Service"
                 }
             },
             "pick_implementation": {

--- a/custom_components/ticktick/translations/en.json
+++ b/custom_components/ticktick/translations/en.json
@@ -18,7 +18,7 @@
         "step": {
             "user": {
                 "title": "Service",
-                "description": "Select TickTick or Dida365. Developer credentials are specific to each service and cannot be shared.",
+                "description": "Select TickTick (international) or Dida365 (China region). Each service uses its own OAuth and API endpoints, and its developer credentials cannot be shared with the other service.",
                 "data": {
                     "region": "Service"
                 }

--- a/custom_components/ticktick/translations/en.json
+++ b/custom_components/ticktick/translations/en.json
@@ -27,6 +27,13 @@
             }
         },
         "step": {
+            "user": {
+                "title": "API endpoint",
+                "description": "Configure the TickTick-compatible API endpoint.",
+                "data": {
+                    "api_endpoint": "API endpoint"
+                }
+            },
             "pick_implementation": {
                 "title": "Pick authentication method"
             }

--- a/custom_components/ticktick/translations/en.json
+++ b/custom_components/ticktick/translations/en.json
@@ -15,6 +15,17 @@
         "create_entry": {
             "default": "Successfully authenticated"
         },
+        "options": {
+            "step": {
+                "init": {
+                    "title": "API endpoint",
+                    "description": "Configure the TickTick-compatible API endpoint.",
+                    "data": {
+                        "api_endpoint": "API endpoint"
+                    }
+                }
+            }
+        },
         "step": {
             "pick_implementation": {
                 "title": "Pick authentication method"


### PR DESCRIPTION
Support 
* Dida365 (China service): `https://api.dida365.com/open/v1`

In addition to
* TickTick (International service): `https://api.ticktick.com/open/v1`

Working for me.

Known limitation: If user add this integration twice, with different service endpoint configured, one overwrites the other. 